### PR TITLE
update decision list regex to be more strict

### DIFF
--- a/webcomponents/besluiten-lijst/main.js
+++ b/webcomponents/besluiten-lijst/main.js
@@ -147,7 +147,7 @@ class BesluitenLijst extends HTMLElement {
         ?label ext:isTaxonomy ?concept .
         VALUES ?thema { <${taxonomy}> }
         VALUES ?concept { ` + conceptsArray.map(concept => `<${concept.trim()}>`).join(" ") + ` }
-        FILTER (!CONTAINS(STR(?url), "/notulen"))
+        FILTER (REGEX(STR(?url), "/agendapunten/[0-9]"))
         FILTER (!CONTAINS(STR(?orgaan), "personeel"))
         FILTER (!CONTAINS(STR(?orgaan), "gemeenteraad"))
       `;


### PR DESCRIPTION
We're only interested in decision detail pages here and can filter those with a simple regex. Note that this means we will not list decisions to only appear on a notulen, decision list or agenda but are not published on their own.