### PR TITLE
update regulations list regex to be more strict

### DIFF
--- a/webcomponents/reglementen-lijst/main.js
+++ b/webcomponents/reglementen-lijst/main.js
@@ -177,7 +177,7 @@ class ReglementenLijst extends HTMLElement {
         VALUES ?concept { ` +
         conceptsArray.map((concept) => `<${concept.trim()}>`).join(" ") +
         ` }
-        FILTER (!CONTAINS(STR(?url), "/notulen"))
+        FILTER (REGEX(STR(?url), "/agendapunten/[0-9]"))
         FILTER (!CONTAINS(STR(?orgaan), "personeel"))
         FILTER (!CONTAINS(STR(?orgaan), "gemeenteraad"))
       `;
@@ -260,7 +260,7 @@ class ReglementenLijst extends HTMLElement {
 
         ${queryThema}
         ${filterparams}
-        FILTER (!CONTAINS(STR(?url), "/notulen"))
+        FILTER (REGEX(STR(?url), "/agendapunten/[0-9]"))
         FILTER (!CONTAINS(STR(?orgaan), "personeel"))
         FILTER (!CONTAINS(STR(?orgaan), "gemeenteraad"))
       }
@@ -293,7 +293,7 @@ class ReglementenLijst extends HTMLElement {
 
         ${queryThema}
         ${filterparams}
-        FILTER (!CONTAINS(STR(?url), "/notulen"))
+        FILTER (REGEX(STR(?url), "/agendapunten/[0-9]"))
         FILTER (!CONTAINS(STR(?orgaan), "personeel"))
         FILTER (!CONTAINS(STR(?orgaan), "gemeenteraad"))
       }`;


### PR DESCRIPTION
We're only interested in decision detail pages here and can filter those with a simple regex. Note that this means we will not list decisions to only appear on a notulen, decision list or agenda but are not published on their own.